### PR TITLE
Bump firenado to 0.2.6.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 bcrypt==3.1.7
-firenado[all]==0.2.1
+firenado[all]==0.2.6
 jsonschema==3.2.0
-passlib==1.7.2
-pycryptodome==3.9.8
+passlib==1.7.4
+pycryptodome==3.10.1
 psycopg2-binary==2.8.6
 trac==1.4.2
 WTForms-Tornado==0.0.2


### PR DESCRIPTION
We cannot go higher than this on firenado as this is the last
relase support python 2.7. Waiting for finally a stable python 3.x
version of trac.

Also:

 - Bump passlib to 1.7.4
 - Bump pycryptodome to 3.10.1