### PR TITLE
Downgrade to firenado 0.2.3.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 bcrypt==3.1.7
-firenado[all]==0.2.6
+firenado[all]==0.2.3
 jsonschema==3.2.0
 passlib==1.7.4
 pycryptodome==3.10.1


### PR DESCRIPTION
This was the latest firenado that would serve python 2.7 correctly.